### PR TITLE
Feature/bug link view on at is broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Features:
 
 Bugfixes:
   - It should not be possible to delete Customer that assigned to the projects -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/9)
+  - Link "View on Aquality Tracking" in report email is broken -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/30)
+  - Link from the audit email notification is invalid -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/13)
 
 ## 0.3.3 (2019-11-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 0.3.4 (unreleased)
+
+Features:
+  - Remove Customers Feature -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/25)
+
+Bugfixes:
+  - It should not be possible to delete Customer that assigned to the projects -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/9)
+
 ## 0.3.3 (2019-11-16)
 
 Features:

--- a/src/app/pages/administration/global/app-settings/app-settings.component.html
+++ b/src/app/pages/administration/global/app-settings/app-settings.component.html
@@ -143,7 +143,8 @@
 </div>
 <div *ngIf="emailSettings" class="panel panel-default">
   <div class="panel-heading">Email Settings
-    <button id="saveEmailSettings"class="btn btn-success btn-sm pull-right panel-button" (click)="saveEmail()">Save</button>
+    <button id="saveEmailSettings" class="btn btn-success btn-sm pull-right panel-button"
+      (click)="saveEmail()">Save</button>
   </div>
   <div class="panel-body">
     <div class="user-email-settings clearfix">
@@ -163,58 +164,68 @@
     </div>
     <div class="notifications clearfix">
       <div class="notifications-expander clearfix settings-section">
-        <div class="col-sm-12">
+        <div class="col-sm-4">
           <ui-switch class="pull-left " size="small" [(ngModel)]="emailSettings.enabled"></ui-switch>
           <label class="pull-left padding-left-15px">Email Notifications</label>
+        </div>
+        <div *ngIf="emailSettings.enabled" class="col-sm-4 field-cell">
+          <div class="col-sm-4">
+            <label for="emailBaseURL" class="label-inline">Base URL</label>
+          </div>
+          <div class="col-sm-8">
+            <input id="emailBaseURL" maxlength="500" class="form-control input-sm" [(ngModel)]="emailSettings.base_url">
+          </div>
         </div>
       </div>
       <div *ngIf="emailSettings.enabled" class="notification-settings settings-section clearfix">
         <div class="col-sm-12">
-          <ui-switch class="pull-left " size="small" [(ngModel)]="emailSettings.use_auth"></ui-switch>
-          <label class="pull-left padding-left-15px">Use STMP Authentication</label>
+          <div class="col-sm-4 field-cell">
+            <ui-switch class="pull-left " size="small" [(ngModel)]="emailSettings.use_auth"></ui-switch>
+            <label class="pull-left padding-left-15px">Use STMP Authentication</label>
+          </div>
         </div>
         <div class="col-sm-4 field-cell">
           <div class="col-sm-4">
-            <label for="ldapSearchBaseUsers" class="label-inline">STMP Host</label>
+            <label for="smtpHost" class="label-inline">STMP Host</label>
           </div>
           <div class="col-sm-8">
-            <input id="ldapSearchBaseUsers" maxlength="100" class="form-control input-sm"
+            <input id="smtpHost" maxlength="100" class="form-control input-sm"
               [(ngModel)]="emailSettings.host" [disabled]="!emailSettings.enabled">
           </div>
         </div>
         <div class="col-sm-4 field-cell">
           <div class="col-sm-4">
-            <label for="ldapSearchBaseUsers" class="label-inline">STMP Port</label>
+            <label for="smtpPort" class="label-inline">STMP Port</label>
           </div>
           <div class="col-sm-8">
-            <input id="ldapSearchBaseUsers" maxlength="4" class="form-control input-sm" [(ngModel)]="emailSettings.port"
+            <input id="smtpPort" maxlength="4" class="form-control input-sm" [(ngModel)]="emailSettings.port"
               [disabled]="!emailSettings.enabled">
           </div>
         </div>
         <div class="col-sm-4 field-cell">
           <div class="col-sm-4">
-            <label for="security_auntification" class="label-inline">STMP Email From</label>
+            <label for="smtpEmailFrom" class="label-inline">STMP Email From</label>
           </div>
           <div class="col-sm-8">
-            <input id="security_auntification" maxlength="100" class="form-control input-sm"
+            <input id="smtpEmailFrom" maxlength="100" class="form-control input-sm"
               [(ngModel)]="emailSettings.from_email" [disabled]="!emailSettings.enabled">
           </div>
         </div>
         <div class="col-sm-4 field-cell">
           <div class="col-sm-4">
-            <label for="security_auntification" class="label-inline">STMP User</label>
+            <label for="smtpUser" class="label-inline">STMP User</label>
           </div>
           <div class="col-sm-8">
-            <input id="security_auntification" maxlength="100" class="form-control input-sm"
+            <input id="smtpUser" maxlength="100" class="form-control input-sm"
               [(ngModel)]="emailSettings.user" [disabled]="!emailSettings.enabled">
           </div>
         </div>
         <div class="col-sm-4 field-cell">
           <div class="col-sm-4">
-            <label for="adminSecret" class="label-inline">STMP Password</label>
+            <label for="smtpPassword" class="label-inline">STMP Password</label>
           </div>
           <div class="col-sm-8">
-            <input id="adminSecret" maxlength="100" class="form-control input-sm" type="password"
+            <input id="smtpPassword" maxlength="100" class="form-control input-sm" type="password"
               [(ngModel)]="emailSettings.password" [disabled]="!emailSettings.enabled">
           </div>
         </div>

--- a/src/app/pages/administration/global/app-settings/app-settings.component.ts
+++ b/src/app/pages/administration/global/app-settings/app-settings.component.ts
@@ -37,6 +37,7 @@ export class AppSettingsComponent implements OnInit {
             this.ldapSettings = res;
         });
         this.emailSettings = await this.emailSettingsService.getEmailSettings();
+        this.setBaseURL();
     }
 
     saveGeneral() {
@@ -70,6 +71,12 @@ export class AppSettingsComponent implements OnInit {
         } else {
             this.emailSettingsService.handleSimpleError(Constants.emailPatternErrorMessageHeader,
                 Constants.emailPatternErrorMessage);
+        }
+    }
+
+    setBaseURL() {
+        if (!this.emailSettings.base_url) {
+            this.emailSettings.base_url = location.origin;
         }
     }
 

--- a/src/app/shared/models/appSettings.ts
+++ b/src/app/shared/models/appSettings.ts
@@ -31,4 +31,5 @@ export class EmailSettings {
   port?: number;
   use_auth?: number;
   default_email_pattern?: string;
+  base_url?: string;
 }


### PR DESCRIPTION
# PR Details
Base URL was added to provide an ability to set base URL for Emails

## Related Issue

  - Link "View on Aquality Tracking" in report email is broken -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/30)
  - Link from the audit email notification is invalid -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/13)

## How Has This Been Tested

Setup Email Settings
Import Test run
Send report to your email
Check links im email

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
