### PR TITLE
Feature/add possibility to filter by inactive milestone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.3.8 (2020-03-02)
+
+Features:
+  - Test Run List: Add posibility to filter by Inactive Milestone -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/73)
+
 ## 0.3.7 (2020-03-02)
 
 Features:

--- a/src/app/elements/table/table.filter.component.html
+++ b/src/app/elements/table/table.filter.component.html
@@ -77,7 +77,7 @@
                         </div>
                         <lookup class="ms-lookup-sm" [small]="true" [cutLongText]="true"
                             [model]="textFilterData(col.property)" *ngIf="col.type === 'link' && col.filter"
-                            placeholder="{{col?.name}} Filter" [allowEmptyValue]="true" [array]="col.lookup.values"
+                            placeholder="{{col?.name}} Filter" [allowEmptyValue]="true" [array]="col.lookup.filterValues ? col.lookup.filterValues : col.lookup.values"
                             (modelChange)="handleFilterChange(col, $event)"></lookup>
 
                         <lookup-colored *ngIf="col.type === 'lookup-colored' && col.filter" [cutLongText]="true"
@@ -95,7 +95,7 @@
 
                         <lookup-autocomplete *ngIf="col.type === 'lookup-autocomplete' && col.filter"
                             [cutLongText]="true" [small]="true" [propertiesToShow]="col.lookup.propToShow"
-                            [array]="col.lookup.values"
+                            [array]="col.lookup.filterValues ? col.lookup.filterValues : col.lookup.values"
                             [placeholder]="col.lookup.placeholder ? col.lookup.placeholder : 'None'"
                             [allowEmptyValue]="true" [model]="getLookupFilterValue(col)[0]"
                             [emptyForFilter]="col.nullFilter"
@@ -118,7 +118,7 @@
                         </div>
                         <lookup-autocomplete-multiselect class="ms-lookup-sm" [cutLongText]="true"
                             *ngIf="col.type === 'multiselect' && col.filter" placeholder="{{col?.name}} Filter"
-                            [propertiesToShow]="col.lookup.propToShow" [array]="col.lookup.values"
+                            [propertiesToShow]="col.lookup.propToShow" [array]="col.lookup.filterValues ? col.lookup.filterValues : col.lookup.values"
                             [model]="getLookupFilterValue(col)"
                             (modelChange)="handleLookupFilterChange(col.property, $event)">
                         </lookup-autocomplete-multiselect>

--- a/src/app/elements/table/tfColumn.ts
+++ b/src/app/elements/table/tfColumn.ts
@@ -42,6 +42,7 @@ export class TFCreation {
 
 export class TFLookup {
     values: any[];
+    filterValues?: any[];
     entity: string;
     objectWithId?: string;
     placeholder?: string;

--- a/src/app/pages/project/testrun/testrun-list/testruns.component.ts
+++ b/src/app/pages/project/testrun/testrun-list/testruns.component.ts
@@ -39,6 +39,7 @@ export class TestRunsComponent implements OnInit {
   testRunStatsFiltered: TestRunStat[];
   testRuns: TestRun[];
   testRun: TestRun;
+  activeMilestones: Milestone[];
   milestones: Milestone[];
   suites: TestSuite[];
   tbCols: TFColumn[];
@@ -67,7 +68,8 @@ export class TestRunsComponent implements OnInit {
       [EGlobalPermissions.manager], [ELocalPermissions.manager, ELocalPermissions.admin]);
     this.canEdit = await this.permissions.hasProjectPermissions(this.testRun.project_id,
       [EGlobalPermissions.manager], [ELocalPermissions.manager, ELocalPermissions.admin, ELocalPermissions.engineer]);
-    this.milestones = await this.milestoneService.getMilestone({ project_id: this.route.snapshot.params.projectId, active: 1 });
+    this.milestones = await this.milestoneService.getMilestone({ project_id: this.route.snapshot.params.projectId});
+    this.activeMilestones = this.milestones.filter(x => !!x.active);
     this.labels = await this.testrunService.getTestsRunLabels(0).toPromise();
     this.suites = await this.testSuiteService.getTestSuite({ project_id: this.route.snapshot.params.projectId });
     this.testRunStats = await this.testrunService.getTestsRunStats({ project_id: this.route.snapshot.params.projectId });
@@ -132,7 +134,8 @@ export class TestRunsComponent implements OnInit {
         sorting: true,
         type: TFColumnType.autocomplete,
         lookup: {
-          values: this.milestones,
+          values: this.activeMilestones,
+          filterValues: this.milestones,
           propToShow: ['name'],
           entity: 'milestone',
           allowEmpty: true


### PR DESCRIPTION
# PR Details


  - Test Run List: Add posibility to filter by Inactive Milestone -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/73)

## Related Issue

  - Test Run List: Add posibility to filter by Inactive Milestone -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/73)

## How Has This Been Tested

Run all tests

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
