### PR TITLE
'Select all' behaviour has been changed for tables. Now selecting will be applied only to active page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.2.0 (2020-12-15)
+ - Fix [Test result view is empty if it was opened by shared link or by opening in new tab] (https://github.com/aquality-automation/aquality-tracking/issues/126)
+ - Fix [Select items on the page] (https://github.com/aquality-automation/aquality-tracking/issues/127)
+ 
 ## 1.1.0 (2020-12-02)
 - added starttls email option
 - fixed logic of disanling username and password fields

--- a/e2e/protractor.conf.js
+++ b/e2e/protractor.conf.js
@@ -25,8 +25,8 @@ exports.config = {
   framework: 'jasmine',
   jasmineNodeOpts: {
     showColors: true,
-    defaultTimeoutInterval: 20000,
-    allScriptsTimeout:40000,
+    defaultTimeoutInterval: 30000,
+    allScriptsTimeout:50000,
     print: function () { }
   },
   onPrepare() {

--- a/e2e/src/pages/administration/apiToken.po/constants.ts
+++ b/e2e/src/pages/administration/apiToken.po/constants.ts
@@ -1,7 +1,7 @@
 import { by, element } from 'protractor';
 import { Autocomplete } from '../../../elements/autocomplete.element';
 
-export const baseUrl = 'administration/project/apiToken';
+export const baseUrl = '/#/administration/project/apiToken';
 
 export const elements = {
     uniqueElement: element(by.css('#api-token-administration.active')),

--- a/e2e/src/pages/administration/permissions.po/constants.ts
+++ b/e2e/src/pages/administration/permissions.po/constants.ts
@@ -2,7 +2,7 @@ import { by, element } from 'protractor';
 import { SmartTable } from '../../../elements/smartTable.element';
 import { Autocomplete } from '../../../elements/autocomplete.element';
 
-export const baseUrl = 'administration/project/permissions';
+export const baseUrl = '/#/administration/project/permissions';
 
 export const elements = {
     uniqueElement: element(by.css('#permissions-administration.active')),

--- a/e2e/src/pages/administration/projectSettings.po/constants.ts
+++ b/e2e/src/pages/administration/projectSettings.po/constants.ts
@@ -3,7 +3,7 @@ import { UiSwitch } from '../../../elements/ui-switch';
 import { Autocomplete } from '../../../elements/autocomplete.element';
 import { Input } from '../../../elements/input.element';
 
-export const baseUrl = 'administration/project/projectSettings';
+export const baseUrl = '/#/administration/project/projectSettings';
 
 export const elements = {
     uniqueElement: element(by.css('#projectSettings-administration.active')),

--- a/e2e/src/pages/administration/resolutions.po/constants.ts
+++ b/e2e/src/pages/administration/resolutions.po/constants.ts
@@ -2,7 +2,7 @@ import { by, element } from 'protractor';
 import { Autocomplete } from '../../../elements/autocomplete.element';
 import { SmartTable } from '../../../elements/smartTable.element';
 
-export const baseUrl = 'administration/project/resolutions';
+export const baseUrl = '/#/administration/project/resolutions';
 
 export const elements = {
     uniqueElement: element(by.css('#resolutions-administration.active')),

--- a/e2e/src/pages/modals/testResultAttachment.po/index.ts
+++ b/e2e/src/pages/modals/testResultAttachment.po/index.ts
@@ -7,7 +7,7 @@ class TestResultAttachmentModalView extends BasePage {
     super(elements.uniqueElement, names.pageName);
   }
 
-  waitForFileNameTimeoutMs : number = 10000;
+  waitForFileNameTimeoutMs : number = 20000;
 
   async getTitle(): Promise<string> {
     return elements.titleElement.getText();

--- a/e2e/src/pages/testrun/create.po/constants.ts
+++ b/e2e/src/pages/testrun/create.po/constants.ts
@@ -2,7 +2,7 @@ import { by, element } from 'protractor';
 import { Autocomplete } from '../../../elements/autocomplete.element';
 import { Input } from '../../../elements/input.element';
 
-export const baseUrl = (projectId: number) => `project/${projectId}/create/testrun`;
+export const baseUrl = (projectId: number) => `/#/project/${projectId}/create/testrun`;
 
 export const elements = {
     uniqueElement: element(by.id('create-test-run')),

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "karma-coverage-istanbul-reporter": "~2.1.0",
     "karma-jasmine": "~3.0.1",
     "karma-jasmine-html-reporter": "^1.4.2",
-    "protractor": "~5.4.3",
+    "protractor": "~7.0.0",
     "superagent": "^5.3.1",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aquality-tracking-ui",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -13,7 +13,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forRoot(routes, { useHash: true })],
   exports: [RouterModule]
 })
 export class AppRoutingModule { }

--- a/src/app/elements/table-filter/data-table/BootstrapPaginator.ts
+++ b/src/app/elements/table-filter/data-table/BootstrapPaginator.ts
@@ -1,5 +1,6 @@
-import {Component, Input, OnChanges} from '@angular/core';
+import {Component, Input, OnChanges, Output, EventEmitter} from '@angular/core';
 import {DataTable} from './DataTable';
+import {PaginatorComponent} from './Paginator';
 import * as _ from 'lodash';
 
 @Component({
@@ -7,37 +8,37 @@ import * as _ from 'lodash';
     template: `
     <table-paginator #p [mfTable]="mfTable">
         <ul class="pagination" *ngIf="p.dataLength > p.rowsOnPage">
-            <li class="page-item" [class.disabled]="p.activePage <= 1" (click)="p.setPage(1)">
+            <li class="page-item" [class.disabled]="p.activePage <= 1" (click)="onClickPage(p, 1)">
                 <a class="page-link" style="cursor: pointer">&laquo;</a>
             </li>
-            <li class="page-item" *ngIf="p.activePage > 4 && p.activePage + 1 > p.lastPage" (click)="p.setPage(p.activePage - 4)">
+            <li class="page-item" *ngIf="p.activePage > 4 && p.activePage + 1 > p.lastPage" (click)="onClickPage(p, p.activePage - 4)">
                 <a class="page-link" style="cursor: pointer">{{p.activePage-4}}</a>
             </li>
-            <li class="page-item" *ngIf="p.activePage > 3 && p.activePage + 2 > p.lastPage" (click)="p.setPage(p.activePage - 3)">
+            <li class="page-item" *ngIf="p.activePage > 3 && p.activePage + 2 > p.lastPage" (click)="onClickPage(p, p.activePage - 3)">
                 <a class="page-link" style="cursor: pointer">{{p.activePage-3}}</a>
             </li>
-            <li class="page-item" *ngIf="p.activePage > 2" (click)="p.setPage(p.activePage - 2)">
+            <li class="page-item" *ngIf="p.activePage > 2" (click)="onClickPage(p, p.activePage - 2)">
                 <a class="page-link" style="cursor: pointer">{{p.activePage-2}}</a>
             </li>
-            <li class="page-item" *ngIf="p.activePage > 1" (click)="p.setPage(p.activePage - 1)">
+            <li class="page-item" *ngIf="p.activePage > 1" (click)="onClickPage(p, p.activePage - 1)">
                 <a class="page-link" style="cursor: pointer">{{p.activePage-1}}</a>
             </li>
             <li class="page-item active">
                 <a class="page-link" style="cursor: pointer">{{p.activePage}}</a>
             </li>
-            <li class="page-item" *ngIf="p.activePage + 1 <= p.lastPage" (click)="p.setPage(p.activePage + 1)">
+            <li class="page-item" *ngIf="p.activePage + 1 <= p.lastPage" (click)="onClickPage(p, p.activePage + 1)">
                 <a class="page-link" style="cursor: pointer">{{p.activePage+1}}</a>
             </li>
-            <li class="page-item" *ngIf="p.activePage + 2 <= p.lastPage" (click)="p.setPage(p.activePage + 2)">
+            <li class="page-item" *ngIf="p.activePage + 2 <= p.lastPage" (click)="onClickPage(p, p.activePage + 2)">
                 <a class="page-link" style="cursor: pointer">{{p.activePage+2}}</a>
             </li>
-            <li class="page-item" *ngIf="p.activePage + 3 <= p.lastPage && p.activePage < 3" (click)="p.setPage(p.activePage + 3)">
+            <li class="page-item" *ngIf="p.activePage + 3 <= p.lastPage && p.activePage < 3" (click)="onClickPage(p, p.activePage + 3)">
                 <a class="page-link" style="cursor: pointer">{{p.activePage+3}}</a>
             </li>
-            <li class="page-item" *ngIf="p.activePage + 4 <= p.lastPage && p.activePage < 2" (click)="p.setPage(p.activePage + 4)">
+            <li class="page-item" *ngIf="p.activePage + 4 <= p.lastPage && p.activePage < 2" (click)="onClickPage(p, p.activePage + 4)">
                 <a class="page-link" style="cursor: pointer">{{p.activePage+4}}</a>
             </li>
-            <li class="page-item" [class.disabled]="p.activePage >= p.lastPage" (click)="p.setPage(p.lastPage)">
+            <li class="page-item" [class.disabled]="p.activePage >= p.lastPage" (click)="onClickPage(p, p.lastPage)">
                 <a class="page-link" style="cursor: pointer">&raquo;</a>
             </li>
         </ul>
@@ -52,12 +53,18 @@ import * as _ from 'lodash';
 export class BootstrapPaginatorComponent implements OnChanges {
     @Input() rowsOnPageSet = [];
     @Input() mfTable: DataTable;
+    @Output() onPageChange: EventEmitter<number> = new EventEmitter();  
 
     minRowsOnPage = 0;
 
     ngOnChanges(changes: any): any {
         if (changes.rowsOnPageSet) {
             this.minRowsOnPage = _.min(this.rowsOnPageSet);
-        }
+        } 
+    }
+
+    onClickPage(paginator: PaginatorComponent, pageNumber: number): void {
+        paginator.setPage(pageNumber);
+        this.onPageChange.emit();
     }
 }

--- a/src/app/elements/table-filter/table-filter.component.html
+++ b/src/app/elements/table-filter/table-filter.component.html
@@ -2,7 +2,7 @@
     [hiddenColumns]="hiddenColumns" [buttons]="[{name:'Apply', execute:true }, {name:'cancel', execute:false}]"
     (execute)="execute($event)" (closed)="wasClosed()"></manage-columns-modal>
 <app-modal *ngIf="!hideBulkDeleteModal" title="Bulk Delete"
-    message="You are about to permanently delete selected Test Runs. You will not be able to recover these Test Runs. This action cannot be undone!"
+    message="You are about to permanently delete {{getSelectedEntitites().length}} selected rows. This action cannot be undone!"
     [type]="'warning'" [buttons]="[{name:'I know what I`m doing', execute:true }, {name:'cancel', execute:false}]"
     (execute)="executeBulkDelete($event)" (closed)="wasClosed()"></app-modal>
 
@@ -60,7 +60,7 @@
                             (contextmenu)="openlink(col.headerlink)"
                             title="Right click to open">{{col?.name}}{{col?.type === 'percent' ? ', %' : ''}}</a>
                         <input *ngIf="col.type === 'selector'" name="select_all" type="checkbox"
-                            [title]="selectAll ? 'Deselect All' : 'Select All'" [ngModel]="selectAll"
+                            [title]="selectAll ? 'Deselect All' : 'Select All'" [(ngModel)]="selectAll"
                             (ngModelChange)="toggleSelectAll($event)" />
                     </th>
                 </tr>
@@ -212,15 +212,15 @@
                         <div *ngIf="col.editable && col.bulkEdit" class="ft-cell">
                             <inline-editor class="full-width" [placeholder]="'Add ' + col?.name"
                                 *ngIf="(col.type === 'text'  || col.type=='email' || col.type=='percent')"
-                                [maxlength]="getMaxLength(col)"
+                                [maxlength]="getMaxLength(col)" 
                                 [name]="col.property" trim="blur"
                                 [ngModel]="transformationsService.getPropertyValue(bulkChangeEntity, col.property)"
                                 (onSave)="setPropertyValue(bulkChangeEntity, col.property, $event, false, false)">
                             </inline-editor>
 
                             <inline-editor class="full-width" [placeholder]="'Add ' + col?.name"
-                                *ngIf="col.type === 'textarea'"
-                                [maxlength]="getMaxLength(col)"
+                                *ngIf="col.type === 'textarea'" 
+                                [maxlength]="getMaxLength(col)" 
                                 [name]="col.property" trim="blur" [config]="{type:'textarea', size:'sm'}"
                                 [ngModel]="transformationsService.getPropertyValue(bulkChangeEntity, col.property)"
                                 (onSave)="setPropertyValue(bulkChangeEntity, col.property, $event, false, false)">
@@ -276,7 +276,7 @@
                             [title]="transformationsService.getPropertyValue(entity, col.title) || ''">
                             <inline-editor class="full-width" [placeholder]="col?.name"
                                 *ngIf="(col.type === 'text'  || col.type=='email' || col.type=='percent') && col.editable && !entity.constantRow && !notEditableByProperty(entity, col)"
-                                [maxlength]="getMaxLength(col)"
+                                [maxlength]="getMaxLength(col)" 
                                 [name]="col.property" trim="blur"
                                 [ngModel]="transformationsService.getPropertyValue(entity, col.property)"
                                 (onSave)="setPropertyValue(entity, col.property, $event)">
@@ -285,7 +285,7 @@
                             <inline-editor class="full-width" [placeholder]="col?.name"
                                 [config]="{type:'textarea', size:'sm'}"
                                 *ngIf="(col.type === 'textarea') && col.editable && !entity.constantRow && !notEditableByProperty(entity, col)"
-                                [maxlength]="getMaxLength(col)"
+                                [maxlength]="getMaxLength(col)" 
                                 [name]="col.property" trim="blur"
                                 [ngModel]="transformationsService.getPropertyValue(entity, col.property)"
                                 (onSave)="setPropertyValue(entity, col.property, $event)">
@@ -426,7 +426,8 @@
             <tfoot *ngIf="!hidePageSets">
                 <tr>
                     <td [attr.colspan]="columns.length">
-                        <bootstrap-paginator class="paginator-bottom" [rowsOnPageSet]="rowsOnPageSet">
+                        <bootstrap-paginator class="paginator-bottom" [rowsOnPageSet]="rowsOnPageSet"
+                            (onPageChange)="displayActivePage()">
                         </bootstrap-paginator>
                     </td>
                 </tr>

--- a/src/app/elements/table-filter/table-filter.component.ts
+++ b/src/app/elements/table-filter/table-filter.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input, Output, EventEmitter, ViewChild, OnInit, AfterViewInit, OnDestroy, OnChanges } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ListToCsvService } from '../../services/listToCsv.service';
+import { CollectionsService } from '../../services/utilities/collections/collections.service';
+import { ChunkedData } from '../../services/utilities/collections/chunked.data';
 import { TransformationsService } from '../../services/transformations.service';
 import { Filter, FilterHelper } from './filter.helper';
 import { NotificationsService } from 'angular2-notifications';
@@ -63,6 +65,7 @@ export class TableFilterComponent implements OnInit, AfterViewInit, OnDestroy, O
   emailFieldError = 'Email should be equal to this pattern: example@domain.com';
   activePage = 1;
   filteredData: any[];
+  chunkedData: ChunkedData;
   showCreation = false;
   appliedFilters: Filter[] = [];
   newEntity: {} = {};
@@ -217,7 +220,14 @@ export class TableFilterComponent implements OnInit, AfterViewInit, OnDestroy, O
   }
 
   toggleSelectAll(isSelected: boolean) {
-    this.filteredData.forEach(entity => entity.ft_select = isSelected);
+    if(this.chunkedData === undefined || (this.chunkedData.chunkSize != this.rowsOnPage)){
+      this.chunkedData = CollectionsService.chunk(this.filteredData, this.rowsOnPage)
+    }
+    this.chunkedData.data[this.activePage - 1].forEach(entity => entity.ft_select = isSelected);
+  }
+
+  displayActivePage(){
+    this.selectAll = false;
   }
 
   hasSelectedRows() {

--- a/src/app/elements/table-filter/table-filter.component.ts
+++ b/src/app/elements/table-filter/table-filter.component.ts
@@ -676,7 +676,8 @@ export class TableFilterComponent implements OnInit, AfterViewInit, OnDestroy, O
   }
 
   openlink(link: string) {
-    window.open(link);
+    let baseUrl = window.location.href.replace(this.router.url, '')
+    window.open(baseUrl + link);
   }
 
   rowClicked(entity: any, col: any, $event: any) {

--- a/src/app/pages/project/results/results-view/testresult-view.component.ts
+++ b/src/app/pages/project/results/results-view/testresult-view.component.ts
@@ -53,7 +53,7 @@ export class TestResultViewComponent implements OnInit {
 
   async ngOnInit() {
     this.projectId = this.route.snapshot.params.projectId;
-    this.listOfResolutions = await this.resultResolutionService.getResolution();
+    this.listOfResolutions = await this.resultResolutionService.getResolution(this.projectId);
     this.listOfFinalResults = await this.finalResultService.getFinalResult({});
     this.issues = (await this.issueService.getIssues({project_id: this.projectId})).filter(x => x.status_id !== 4);
     let projectUsers: LocalPermissions[] = await this.userService.getProjectUsers(this.projectId);

--- a/src/app/services/utilities/collections/chunked.data.ts
+++ b/src/app/services/utilities/collections/chunked.data.ts
@@ -1,0 +1,9 @@
+export class ChunkedData {
+    data: any[];
+    chunkSize: number;
+
+  constructor(data: any[], chunkSize: number) {
+    this.data = data;
+    this.chunkSize = chunkSize;
+  }    
+}

--- a/src/app/services/utilities/collections/collections.service.ts
+++ b/src/app/services/utilities/collections/collections.service.ts
@@ -1,0 +1,15 @@
+import { ChunkedData } from './chunked.data';
+
+
+export class CollectionsService {
+  constructor() { }
+
+  static chunk(data: any[], size: number) : ChunkedData {
+    let result = []
+    for (let i = 0; i < data.length; i += size) {
+      let chunk = data.slice(i, i + size)
+      result.push(chunk)
+    }
+    return new ChunkedData(result, size);
+  }
+}


### PR DESCRIPTION
added fixes of:
https://github.com/aquality-automation/aquality-tracking/issues/126
https://github.com/aquality-automation/aquality-tracking/issues/127

applied 2-ways-binding to selectAll
added onPageChange to paginator
selectAll will be applied only to active page
added collections utilities

# PR Details

https://github.com/aquality-automation/aquality-tracking/issues/127

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
